### PR TITLE
logstash: set glob for input files

### DIFF
--- a/src/config/logstash/logstash.conf
+++ b/src/config/logstash/logstash.conf
@@ -1,6 +1,6 @@
 input {
   file { 
-    path => ["/var/log/suricata/eve.json"]
+    path => ["/var/log/suricata/*.json"]
     #sincedb_path => ["/var/lib/logstash/"]
     codec =>   json 
     type => "SELKS" 


### PR DESCRIPTION
This permits to load different log files in /var/log/suricata
and use them as input files
