### PR TITLE
Update logstash.conf

### DIFF
--- a/src/config/logstash/logstash.conf
+++ b/src/config/logstash/logstash.conf
@@ -54,7 +54,7 @@ filter {
 
 output { 
   elasticsearch {
-    host => elasticsearch
+    hosts => 'elasticsearch:9200'
     #protocol => http
   }
   #stdout { codec => rubydebug }


### PR DESCRIPTION
host => is deprecated and replaced by hosts => which is now a comma seperated array.
