### PR TITLE
Add EveBox.

### DIFF
--- a/src/config/logstash/logstash.conf
+++ b/src/config/logstash/logstash.conf
@@ -54,8 +54,7 @@ filter {
 
 output { 
   elasticsearch {
-    host => elasticsearch
-    #protocol => http
+    hosts => elasticsearch
   }
   #stdout { codec => rubydebug }
 }

--- a/src/templates/docker-compose.yml.j2
+++ b/src/templates/docker-compose.yml.j2
@@ -54,3 +54,10 @@ sciriusdata:
     command: /bin/true
     volumes:
         - /sciriusdata
+
+evebox:
+    image: jasonish/evebox:latest
+    ports:
+        - 5636:5636
+    links:
+        - elasticsearch


### PR DESCRIPTION
The first commit just fixes the Logstash config for the version of Logstash you get with a recent docker pull.  Might I suggest pinning the elasticsearch and logstash versions?

The second commit adds my EveBox image. This is my development branch of EveBox which has diverged somewhat from the old version, but runs in a busybox based container, so its small and requires no modification to your Logstash or ElasticSearch config like previous versions did.
