### PR TITLE
Create blank file to allow suricata to start

### DIFF
--- a/src/docker/suricata/Dockerfile
+++ b/src/docker/suricata/Dockerfile
@@ -8,5 +8,6 @@ run apt-get update
 run DEBIAN_FRONTEND=noninteractive apt-get install -y suricata supervisor python-pyinotify psmisc
 COPY supervisor.d/* /etc/supervisor/conf.d/
 COPY suri_reloader /usr/local/sbin/suri_reloader
+run touch /etc/suricata/threshold.config
 
 CMD ["/usr/bin/supervisord", "-n"]


### PR DESCRIPTION
This will hopefully fix issue #7 by creating an empty file, which will allow suricata to start.
