### PR TITLE
Set default backup path for scirius in Amsterdam

### DIFF
--- a/src/config/scirius/local_settings.py
+++ b/src/config/scirius/local_settings.py
@@ -33,3 +33,7 @@ DATABASES = {
 GIT_SOURCES_BASE_DIRECTORY = os.path.join(DATA_DIR, 'git-sources/')
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+DBBACKUP_STORAGE = 'dbbackup.storage.filesystem_storage'
+DBBACKUP_STORAGE_OPTIONS = {'location': '/var/backups/'}
+


### PR DESCRIPTION
According to the Scirius readme the backups should go into: /var/backups

> With default configuration file, the backup is done on disk in /var/backups but other methods are available.
