### PR TITLE
systemd service for starting/stopping amsterdam

### DIFF
--- a/scripts/systemd/amsterdam.service
+++ b/scripts/systemd/amsterdam.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Amsterdam
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/amsterdam -d /opt/ams start
+ExecStop=/usr/bin/amsterdam -d /opt/ams stop
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Needs to go in:

/usr/lib/systemd/system/

start/stop/restart:
systemctl start amsterdam
systemctl stop amsterdam
systemctl restart amsterdam

start at boot:
systemctl enable amsterdam
