### PR TITLE
Increase timeout

### DIFF
--- a/src/config/nginx/amsterdam.conf
+++ b/src/config/nginx/amsterdam.conf
@@ -17,7 +17,7 @@ server {
 
     location / {
         proxy_pass http://scirius:8000;
-        proxy_read_timeout 600;
+        proxy_read_timeout 2400;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Proto https;
         proxy_redirect off;


### PR DESCRIPTION
Avoid getting 502 from nginx when calling "update, build & push" rules.
