### PR TITLE
Allows users to access SCIRIUS by default

### DIFF
--- a/src/config/scirius/local_settings.py
+++ b/src/config/scirius/local_settings.py
@@ -1,5 +1,7 @@
 import os
 
+ALLOWED_HOSTS = ['*']
+
 USE_ELASTICSEARCH = True
 ELASTICSEARCH_ADDRESS = "elasticsearch:9200"
 ELASTICSEARCH_2X = True


### PR DESCRIPTION
In Amsterdam's current state, it gives an Internal
Server error because there is now ALLOWED_HOSTS in the config file.

This adjustment will allow users to access the docker container as soon
as it comes up.